### PR TITLE
Established downratings

### DIFF
--- a/agency/python/src/reputation_service_api.py
+++ b/agency/python/src/reputation_service_api.py
@@ -93,6 +93,10 @@ class PythonReputationService(object):
             self.decayed = changes['decayed']
         else:
             self.decayed = 0
+        if 'downrating' in changes.keys():
+            self.downrating = changes['downrating']
+        else:
+            self.downrating = False   
         self.default=default1
         self.conservatism = conservatism
         self.precision = precision
@@ -161,7 +165,6 @@ class PythonReputationService(object):
 
     def convert_data(self,data):
         daily_data = data[['from','type','to','weight','time','value','type']].to_dict("records")
-        
         self.all_dates()
         i = 0
         while i<len(daily_data):
@@ -170,8 +173,7 @@ class PythonReputationService(object):
             i+=1
         self.ratings = daily_data
         return(daily_data)
-             
-        
+
         
     def update_ranks(self,mydate):
         ### And then we iterate through functions. First we prepare arrays and basic computations.
@@ -189,9 +191,13 @@ class PythonReputationService(object):
         problem = False 
         
         start1 = time.time()
+        if len(self.current_ratings)>0:
+            if (self.current_ratings[0]['type']=="payment" and self.downrating==True):
+                print("if we only have payments, we have no ratings. Therefore downratings cannot be True. Setting them to False")
+                self.downrating=False
         
         array1 , dates_array, to_array, first_occurance = reputation_calc_p1(self.current_ratings,self.first_occurance,self.precision,
-                                                                             self.temporal_aggregation,False,self.logratings)  
+                                                                             self.temporal_aggregation,False,self.logratings,self.downrating)  
         self.first_occurance = first_occurance
         self.reputation = update_reputation(self.reputation,array1,self.default)
         since = self.date - timedelta(days=self.update_period)


### PR DESCRIPTION
Established downratings. But still many errors.
======================================================================
ERROR: testPaymentsNoFeedback (test_reputation_simulation.TestReputationSimulation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation_simulation.py", line 78, in testPaymentsNoFeedback
    self.assertEqual(str(round(float(lines[len(lines)-7]),14)),'0.98218768825066')
ValueError: could not convert string to float:

======================================================================
ERROR: testRatingsNoFeedback (test_reputation_simulation.TestReputationSimulation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation_simulation.py", line 62, in testRatingsNoFeedback
    self.assertEqual(str(round(float(lines[len(lines)-7]),14)),'0.99492702563191')
ValueError: could not convert string to float:

======================================================================
FAIL: test_base (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 123, in test_base
    self.assertEqual(rank['rank'], 33)
AssertionError: 0.0 != 33

======================================================================
FAIL: test_decayed (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 164, in test_decayed
    self.assertEqual(ranks['4'], 8)
AssertionError: 0.0 != 8

======================================================================
FAIL: test_downrating (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 347, in test_downrating
    self.assertEqual(ranks['4'], 49)
AssertionError: 0.0 != 49

======================================================================
FAIL: test_fullnorm (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 240, in test_fullnorm
    self.assertEqual(ranks['3'], 50) # because its logarithmic differential is normalized down to 0
AssertionError: 0.0 != 50

======================================================================
FAIL: test_liquid (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 266, in test_liquid
    self.assertEqual(ranks['1'], 0)
AssertionError: 100.0 != 0

======================================================================
FAIL: test_logratings (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 393, in test_logratings
    self.assertEqual(ranks['3'], 56)
AssertionError: -2.0 != 56

======================================================================
FAIL: test_period (test_aigents_reputation.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 297, in test_period
    self.assertEqual(ranks['1'], 25)
AssertionError: 0.0 != 25

======================================================================
FAIL: test_base (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 123, in test_base
    self.assertEqual(rank['rank'], 33)
AssertionError: 0.0 != 33

======================================================================
FAIL: test_decayed (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 164, in test_decayed
    self.assertEqual(ranks['4'], 8)
AssertionError: 0.0 != 8

======================================================================
FAIL: test_downrating (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 347, in test_downrating
    self.assertEqual(ranks['4'], 49)
AssertionError: 0.0 != 49

======================================================================
FAIL: test_fullnorm (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 240, in test_fullnorm
    self.assertEqual(ranks['3'], 50) # because its logarithmic differential is normalized down to 0
AssertionError: 0.0 != 50

======================================================================
FAIL: test_liquid (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 266, in test_liquid
    self.assertEqual(ranks['1'], 0)
AssertionError: 100.0 != 0

======================================================================
FAIL: test_logratings (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 393, in test_logratings
    self.assertEqual(ranks['3'], 56)
AssertionError: -2.0 != 56

======================================================================
FAIL: test_period (test_aigents_reputation_api.TestAigentsAPIReputationService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 297, in test_period
    self.assertEqual(ranks['1'], 25)
AssertionError: 0.0 != 25

======================================================================
FAIL: test_downrating (test_reputation_service_api.TestPythonReputationService2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 347, in test_downrating
    self.assertEqual(ranks['4'], 49)
AssertionError: 40 != 49

======================================================================
FAIL: test_fullnorm (test_reputation_service_api.TestPythonReputationService2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 248, in test_fullnorm
    self.assertEqual(ranks['3'], 96) # because its logarithmic differential is not normalized down to 0
AssertionError: 95 != 96

======================================================================
FAIL: test_logratings (test_reputation_service_api.TestPythonReputationService2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 393, in test_logratings
    self.assertEqual(ranks['3'], 56)
AssertionError: 57 != 56

======================================================================
FAIL: test_precision (test_reputation_service_api.TestPythonReputationService2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation.py", line 371, in test_precision
    self.assertEqual(ranks['2'], 49)
AssertionError: 63 != 49

======================================================================
FAIL: testRatingsWithFeedback (test_reputation_simulation.TestReputationSimulation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nejc/API_test/testing/github_copy/v2/python/src/test_reputation_simulation.py", line 91, in testRatingsWithFeedback
    assert r1['1'] > 60
AssertionError

