### PR TITLE
Some bug fixes

### DIFF
--- a/agency/python/src/reputation_service_api.py
+++ b/agency/python/src/reputation_service_api.py
@@ -117,7 +117,7 @@ class PythonReputationService(ReputationServiceBase):
         return({'default': self.default, 'conservatism':self.conservatism, 'precision':self.precision,
                'weighting':self.weighting,'fullnorm':self.fullnorm, 'liquid':self.liquid,'logranks':self.logranks,
                'aggregation':self.temporal_aggregation, 'logratings':self.logratings, 'update_period':self.update_period,
-               'use_ratings':self.use_ratings, 'date':self.date,'decayed':self.decayed})
+               'use_ratings':self.use_ratings, 'date':self.date,'decayed':self.decayed,'downrating':self.downrating})
     ## Update date
     def set_date(self,newdate):
         self.our_date = newdate
@@ -213,7 +213,7 @@ class PythonReputationService(ReputationServiceBase):
         ### Downratings seem to pass, so I assume this comment is resolved.
         self.reputation = normalize_reputation(self.reputation,self.downrating)
         
-        self.all_reputations[mydate] = self.reputation
+        self.all_reputations[mydate] = dict(self.reputation)
         return(0)
         
     def update_ratings(self, ratings, mydate):


### PR DESCRIPTION
Some bug fixes. Fixed return in get_parameters. There was also a missed bug in getting ranks from days other than previous day - then we get wrong values.

However, after running performance_test, there is still an existing problem, so this did not solve it. Perhaps this will help in comparison to development of Java code;  the development of rating for agent '500' in Python:
reputations saved by date 2018-01-01 {'id': '500', 'rank': 86.0}
reputations saved by date 2018-01-02 {'id': '500', 'rank': 75.0}
reputations saved by date 2018-01-03 {'id': '500', 'rank': 69.0}
reputations saved by date 2018-01-04 {'id': '500', 'rank': 43.0}
reputations saved by date 2018-01-05 {'id': '500', 'rank': 62.0}
reputations saved by date 2018-01-06 {'id': '500', 'rank': 42.0}
reputations saved by date 2018-01-07 {'id': '500', 'rank': 47.0}
reputations saved by date 2018-01-08 {'id': '500', 'rank': 41.0}
reputations saved by date 2018-01-09 {'id': '500', 'rank': 34.0}
reputations saved by date 2018-01-10 {'id': '500', 'rank': 46.0}
reputations saved by date 2018-01-11 {'id': '500', 'rank': 45.0}
reputations saved by date 2018-01-12 {'id': '500', 'rank': 40.0}
reputations saved by date 2018-01-13 {'id': '500', 'rank': 47.0}
reputations saved by date 2018-01-14 {'id': '500', 'rank': 66.0}
reputations saved by date 2018-01-15 {'id': '500', 'rank': 63.0}
reputations saved by date 2018-01-16 {'id': '500', 'rank': 41.0}
reputations saved by date 2018-01-17 {'id': '500', 'rank': 48.0}
reputations saved by date 2018-01-18 {'id': '500', 'rank': 55.0}
reputations saved by date 2018-01-19 {'id': '500', 'rank': 64.0}
reputations saved by date 2018-01-20 {'id': '500', 'rank': 56.0}
reputations saved by date 2018-01-21 {'id': '500', 'rank': 54.0}
reputations saved by date 2018-01-22 {'id': '500', 'rank': 61.0}
reputations saved by date 2018-01-23 {'id': '500', 'rank': 38.0}
reputations saved by date 2018-01-24 {'id': '500', 'rank': 47.0}
reputations saved by date 2018-01-25 {'id': '500', 'rank': 38.0}
reputations saved by date 2018-01-26 {'id': '500', 'rank': 54.0}
reputations saved by date 2018-01-27 {'id': '500', 'rank': 53.0}
reputations saved by date 2018-01-28 {'id': '500', 'rank': 68.0}
