### PR TITLE
Found fix for #193 but fix invalidates more tests

### DIFF
--- a/reputation/reputation_calculation.py
+++ b/reputation/reputation_calculation.py
@@ -544,11 +544,20 @@ def calculate_new_reputation(new_array,to_array,reputation,rating,precision,defa
     ### We divide it by max value, as specified. There are different normalizations possible...
     return(mys)
 
-def normalized_differential(mys,normalizedRanks,our_default):
+def normalized_differential(raw,normalizedRanks,our_default,log=True):
+    if log:
+        mys = {}
+        for k in raw.keys():
+        	v = raw[k]
+        	# f = v < 0 ? -log10(1 - v) : log10(1 + v)
+        	mys[k] = -np.log10(1 - v) if v < 0 else np.log10(1 + v)
+    else:
+        mys = raw
     max_value = max(mys.values(), default=1)
     min_value = min(mys.values(), default=0)
     if max_value==min_value:
         min_value = max_value - our_default ### as the solution to issue #157
+    #print(normalizedRanks,min_value,max_value)
     for k in mys.keys():
         if max_value==min_value:
             mys[k] = (mys[k]-min_value)

--- a/reputation/reputation_service_api.py
+++ b/reputation/reputation_service_api.py
@@ -246,7 +246,10 @@ class PythonReputationService(ReputationServiceBase):
         new_reputation = calculate_new_reputation(new_array = array1,to_array = to_array,reputation = self.reputation,rating = self.use_ratings,precision = self.precision,default=self.default,unrated=self.unrated,normalizedRanks=self.fullnorm,weighting = self.weighting,denomination = self.denomination, liquid = self.liquid, logratings = self.logratings,logranks = self.logranks) 
         ### And then update reputation.
         ### In our case we take approach c.
-        new_reputation = normalized_differential(new_reputation,normalizedRanks=self.fullnorm,our_default=self.default)
+        #print(new_reputation)
+        #TODO figure out why log=True causes other 6 tests to fail
+        new_reputation = normalized_differential(new_reputation,normalizedRanks=self.fullnorm,our_default=self.default,log=False)
+        #print(new_reputation)
         self.reputation = update_reputation_approach_d(self.first_occurance,self.reputation,new_reputation,since,
                                                        self.date, self.decayed,self.conservatism)
         ### Apply normalizedRanks=True AKA "full normalization" to prevent negative ratings on "downrating"

--- a/reputation/test_reputation.py
+++ b/reputation/test_reputation.py
@@ -721,9 +721,10 @@ class TestReputationServiceDebug(TestReputationServiceAdvanced):
 		def get_data_in():
 			#transactions = pd.read_csv('./testdata/issue1.tsv',header = None,sep="\t") 
 			
-			#for 10 transactions in issue1.tsv results are the same
-			#for 25 transactions in issue1.tsv results are different
-			transactions = pd.read_csv('./testdata/issue1_25.tsv',header = None,sep="\t") 
+			# The data in issue1_25.tsv have issue #171
+			#transactions = pd.read_csv('./testdata/issue1_25.tsv',header = None,sep="\t") 
+			
+			transactions = pd.read_csv('./testdata/issue1_16cleaned.tsv',header = None,sep="\t") 
 
 			transactions.columns = ['what','Time','type','from','to','value','unit','child','parent','title',
 			                        'input','tags','format','block','parent']
@@ -780,12 +781,12 @@ class TestReputationServiceDebug(TestReputationServiceAdvanced):
 		#Let us ignore that for now, may fix later in #192 . 
 		#ratings_cnt = len(rs.get_ratings({'ids':['0','1','2'],'since':datetime.date(2017, 1, 1),'until':datetime.date(2018, 1, 2)})[1])
 		ratings_cnt = 0
-		ratings_cnt += len(rs.get_ratings({'ids':['0'],'since':date1,'until':date1})[1]);
+		ratings_cnt += len(rs.get_ratings({'ids':['50'],'since':date1,'until':date1})[1]);
 		ratings_cnt += len(rs.get_ratings({'ids':['1'],'since':date1,'until':date1})[1]);
 		ratings_cnt += len(rs.get_ratings({'ids':['2'],'since':date1,'until':date1})[1]);
 
-		print(ratings_cnt)
-		print(ranks)
+		#print(ratings_cnt)
+		#print(ranks)
 		
 		### The following applies to ./testdata/issue1.tsv
 		### Why 265? If we look at all the transactions in issue1.tsv, we can see there are 582 of them. If we filter
@@ -795,9 +796,24 @@ class TestReputationServiceDebug(TestReputationServiceAdvanced):
 		### About the second assertEqual - not certain if it's correct, but this is what Python rep system returns.
 
 		### The following applies to ./testdata/issue1_25.tsv
-		self.assertEqual(ratings_cnt,20)
+		#self.assertEqual(ratings_cnt,25)
 		#self.assertDictEqual(ranks,{'50': 100.0, '1': 43.0, '2': 33.0}) # Java
-		self.assertDictEqual(ranks,{'2': 33.0, '50': 100.0, '1': 36.0}) # Python
+		#self.assertDictEqual(ranks,{'2': 33.0, '50': 100.0, '1': 36.0}) # Python
+		
+		### The following applies to ./testdata/issue1_16cleaed.tsv
+		self.assertEqual(ratings_cnt,16)
+		
+		# Java
+		#differential: {2=600.0, 1=500.0, 50=400.0}
+		#normalized: {2=100.0, 1=55.02378567291773, 50=0.0}
+		#blended: {2=75.0, 1=52.51189283645887, 50=25.0}
+		#normalized: {2=100.0, 1=70.0158571152785, 50=33.33333333333333}
+		#self.assertDictEqual(ranks,{'2': 100.0, '1': 70.0, '50': 33.0})
+		
+		# Python
+		#differential: {'2': 600.0, '50': 400.0, '1': 500.0}
+		#normalized: {'2': 1.0, '50': 0.0, '1': 0.5}
+		self.assertDictEqual(ranks,{'2': 100.0, '50': 33.0, '1': 67.0}) # Python
 		
 
 	#TODO Test self.parameters['logranks'] after when implemented:

--- a/reputation/test_reputation_service_api.py
+++ b/reputation/test_reputation_service_api.py
@@ -27,8 +27,8 @@ import unittest
 from test_reputation import *
 from reputation_service_api import *
 
-class TestPythonReputationService(TestReputationServiceDebug,unittest.TestCase):
 #class TestPythonReputationService(TestReputationServiceDebug,unittest.TestCase):
+class TestPythonReputationService(TestReputationServiceDebug,unittest.TestCase):
     def setUp(self):
         self.rs = PythonReputationService()
         params = {'default':0.5, 'conservaticism': 0.5, 'precision': 0.01, 'weighting': True, 'fullnorm': True,'liquid': True, 'logranks': True, 'temporal_aggregation': False, 'logratings': False, 'days_jump': 1, 'use_ratings': True, 'start_date': datetime.date(2018, 1, 1)}

--- a/reputation/testdata/issue1_16cleaned.tsv
+++ b/reputation/testdata/issue1_16cleaned.tsv
@@ -1,0 +1,16 @@
+singularity	1514817534	rating	44	2	1		2848	8742			product0			68.91269451
+singularity	1514813485	rating	44	2	1		8250	2880			product0			67.64596281
+singularity	1514812408	rating	44	2	1		2768	1076			product0			67.90218841
+singularity	1514812823	rating	555	2	0		284	1206			product0			68.54177782
+singularity	1514810730	rating	304	50	1		7708	4050			product0			68.69326433
+singularity	1514817565	rating	304	50	1		8361	8682			product0			68.92622239
+singularity	1514810579	rating	304	50	1		5957	5813			product0			67.7679164
+singularity	1514814646	rating	304	50	1		8376	772			product0			68.28918929
+singularity	1514813241	rating	49	1	1		4020	3115			product0			69.38297272
+singularity	1514817027	rating	37	1	1		405	6315			product0			68.99359251
+singularity	1514809916	rating	37	1	1		8602	1405			product0			67.63981167
+singularity	1514811877	rating	37	1	1		6782	1878			product0			68.56863497
+singularity	1514815939	rating	37	1	1		4976	1656			product0			68.79270971
+singularity	1514812200	rating	23	2	1		5462	8992			product0			68.64423543
+singularity	1514810484	rating	23	2	1		6730	1072			product0			68.75823797
+singularity	1514813101	rating	23	2	1		6079	84			product0			67.88677434


### PR DESCRIPTION
So @nejc9921 please apply the fix calling 

        #TODO figure out why log=True causes other 6 tests to fail
        new_reputation = normalized_differential(new_reputation,normalizedRanks=self.fullnorm,our_default=self.default,log=True)

and explore why the other tests are failing and how to fix them.