### PR TITLE
Hacky fix for discrepancy having Python weighting ratings

### DIFF
--- a/reputation/reputation_calculation.py
+++ b/reputation/reputation_calculation.py
@@ -516,8 +516,9 @@ def calculate_new_reputation(new_array,to_array,reputation,rating,precision,defa
                     amounts.append(new_rating * rater_reputation(reputation,new_array[k][0],default,liquid=liquid))#*100*precision**-1
                     #no need for denomination by sum of weights in such case 
             mys[unique_ids[i]] = sum(amounts)
-            if len(denominators) > 0:
-                myd[unique_ids[i]] = sum(denominators)
+            if weighting:
+                if len(denominators) > 0:
+                    myd[unique_ids[i]] = sum(denominators)
 #
             i+=1
     else:
@@ -538,9 +539,11 @@ def calculate_new_reputation(new_array,to_array,reputation,rating,precision,defa
                     break             
             mys[unique_ids[i]] = sum(amounts)          
             i+=1
-    if denomination and len(mys) == len(myd):
-        for k, v in mys.items():
-            mys[k] = v / myd[k]
+    #print("calculation",mys)
+    if weighting:
+        if denomination and len(mys) == len(myd):
+            for k, v in mys.items():
+                mys[k] = v / myd[k]
 
     ### nr 5.
     ### Here we make trasformation in the same way as described in point 5

--- a/reputation/reputation_service_api.py
+++ b/reputation/reputation_service_api.py
@@ -254,12 +254,24 @@ class PythonReputationService(ReputationServiceBase):
             spendings_dict = spending_based(array1,dict(),self.logratings,self.precision,self.weighting)
             spendings_dict = normalized_differential(spendings_dict,normalizedRanks=self.fullnorm,our_default=self.default,spendings=self.spendings,log=False)        
         
-        new_reputation = calculate_new_reputation(new_array = array1,to_array = to_array,reputation = self.reputation,rating = self.use_ratings,precision = self.precision,default=self.default,unrated=self.unrated,normalizedRanks=self.fullnorm,weighting = self.weighting,denomination = self.denomination, liquid = self.liquid, logratings = self.logratings,logranks = self.logranks) 
+        #print('update_reputation',self.reputation)
+        
+        ###TODO Ok, we have the reputation computed above! Why do we need to do the calculate_new_reputation over again!!!???
+        ### @akolonin: hack to avoid apparent redundancy 
+        if self.weighting:
+            new_reputation = calculate_new_reputation(new_array = array1,to_array = to_array,reputation = self.reputation,rating = self.use_ratings,precision = self.precision,default=self.default,unrated=self.unrated,normalizedRanks=self.fullnorm,weighting = self.weighting,denomination = self.denomination, liquid = self.liquid, logratings = self.logratings,logranks = self.logranks) 
+        else:
+            new_reputation = self.reputation
+
         ### And then update reputation.
         ### In our case we take approach c.
-        #print(new_reputation)
+        
+        #print('calculate_new_reputation',new_reputation)
+        
         #TODO figure out why log=True causes other 6 tests to fail
         new_reputation = normalized_differential(new_reputation,normalizedRanks=self.fullnorm,our_default=self.default,spendings=self.spendings,log=False)
+ 
+ 
         if self.spendings>0:
             updated_differential = dict()
             unique_keys = list(new_reputation.keys())


### PR DESCRIPTION
Hacky fix for discrepancy having Python weighting ratings which are not supposed to get weighted - wonder about computational redundancy in the code - looks like the same thing is computed over and over again in multiple ways - @nejc9921 please review carefully and take action as necessary. 