### PR TITLE
spendings_normalization

### DIFF
--- a/reputation/test_reputation.py
+++ b/reputation/test_reputation.py
@@ -890,9 +890,25 @@ class TestReputationServiceAdvanced(TestReputationServiceParametersBase):
 
 		ranks = rs.get_ranks_dict({'date':dt2})
 		self.assertEqual(ranks['1'],68)
-
+	def test_spendings_normalization(self):
+		rs = self.rs
+		rs.clear_ratings()
+		rs.clear_ranks()
+		dt2 = datetime.date(2018, 1, 2)
+		self.assertEqual(rs.put_ratings([{'from':5,'type':'rating','to':2,'value':0.25,'weight':682,'time':dt2}]),0)
+		self.assertEqual(rs.put_ratings([{'from':6,'type':'rating','to':3,'value':1,'weight':220,'time':dt2}]),0)
+		self.assertEqual(rs.put_ratings([{'from':7,'type':'rating','to':4,'value':1,'weight':583,'time':dt2}]),0)
+		self.assertEqual(rs.put_ratings([{'from':8,'type':'rating','to':2,'value':1,'weight':196,'time':dt2}]),0)
+		self.assertEqual(rs.put_ratings([{'from':10,'type':'rating','to':9,'value':1,'weight':129,'time':dt2}]),0)
+		rs.set_parameters({'fullnorm':True,'weighting':True ,'logratings':False,'downrating':False,'denomination':True ,'unrated':False,'default':0.0,'decayed':0.5,'ratings':0.9,'spendings':0.1,'conservatism':0.5})
+		self.assertEqual(rs.update_ranks(dt2),0)
+		ranks = rs.get_ranks_dict({'date':dt2})
+		self.assertDictEqual(ranks,{'2': 0.0, '5': 100.0, '3': 0.0, '6': 16.0, '4': 0.0, '7': 82.0, '8': 12.0, '9': 0.0, '10': 0.0})
+		rs.clear_ratings()
+		rs.clear_ranks()  
+		self.clear()  
 
 class TestReputationServiceDebug(object):
-
+	#TODO more tests?
 	#TODO more tests?
 	pass


### PR DESCRIPTION
I found the issue and made a unittest with the differences. The meat of the issue is quite simple. There are 5 transactions and after update_ranks() method, they get different ranks. Java and Python seem to agree that ratings play no role here - the only thing that moves ranks are spendings.

Spendings are calculated differently. I suspect the difference is in normalization, but it could as well be in calculation of spendings. I will go through exact process here;
Relevant code:
self.assertEqual(rs.put_ratings([{'from':5,'type':'rating','to':2,'value':0.25,'weight':682,'time':dt2}]),0)
		self.assertEqual(rs.put_ratings([{'from':6,'type':'rating','to':3,'value':1,'weight':220,'time':dt2}]),0)
		self.assertEqual(rs.put_ratings([{'from':7,'type':'rating','to':4,'value':1,'weight':583,'time':dt2}]),0)
		self.assertEqual(rs.put_ratings([{'from':8,'type':'rating','to':2,'value':1,'weight':196,'time':dt2}]),0)
		self.assertEqual(rs.put_ratings([{'from':10,'type':'rating','to':9,'value':1,'weight':129,'time':dt2}]),0)
		rs.set_parameters({'fullnorm':True,'weighting':True ,'logratings':False,'downrating':False,'denomination':True ,'unrated':False,'default':0.0,'decayed':0.5,'ratings':0.9,'spendings':0.1,'conservatism':0.5})

Python gets the following ranks:
{'2': 0.0, '5': 100.0, '3': 0.0, '6': 16.0, '4': 0.0, '7': 82.0, '8': 12.0, '9': 0.0, '10': 0.0}
And Java:
{'5': 100.0, '7': 91.0, '6': 32.0, '8': 25.0, '10': 0.0, '2': 0.0, '3': 0.0, '4': 0.0, '9': 0.0}

I am again not sure how Java gets those numbers. But for Python, it goes this way:
First, spendings get summed; 
 {'5': 68200.0, '6': 22000.0, '7': 58300.0, '8': 19600.0, '10': 12900.0}
Then, they get normalized (fullnorm=True):
{'5': 1.0, '6': 0.16455696202531644, '7': 0.8209764918625678, '8': 0.12115732368896925, '10': 0.0}

and then we more or less get the numbers that I mentioned. I failed to find out how Java behaves, so currently I am stuck at this point.