### PR TITLE
reputation_buying study competition

### DIFF
--- a/reputation/reputation_buying_test.py
+++ b/reputation/reputation_buying_test.py
@@ -48,6 +48,10 @@ verbose = False
 good_transactions = 1
 bad_transactions = 1
 
+good_agent = {"buyers":[1,800], "products":[1001,1800], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
+bad_agent = {"buyers":[801,1000], "products":[1801,2000], "qualities":[0.0,0.25], "transactions": bad_transactions}
+days = 1001
+
 good_agent = {"buyers":[1,80], "products":[101,180], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
 bad_agent = {"buyers":[81,100], "products":[181,200], "qualities":[0.0,0.25], "transactions": bad_transactions}
 days = 101
@@ -60,7 +64,7 @@ days = 101
 #bad_agent = {"buyers":[4,5], "products":[9,10], "qualities":[0.0,0.25], "transactions": bad_transactions}
 #days = 5
 
-
+"""
 print("RS=None", end =" ")
 reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 0, None, verbose)
 
@@ -68,26 +72,62 @@ print("RS=Regular", end =" ")
 reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 0, rs, verbose)
 
 print("RS=Regular", end =" ")
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 50, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
 
 print("RS=Regular", end =" ")
 reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 100, rs, verbose)
 
 print("RS=Weighted", end =" ")
 rs.set_parameters({'rating_bias':False,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 50, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
 
 print("RS=Biased", end =" ")
 rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 50, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
 
 print("RS=TOM-based", end =" ")
 rs.set_parameters({'rating_bias':False,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':True ,'default':0.0,'decayed':0.5,'ratings':1.0,'spendings':0.0})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 50, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
 	
 print("RS=SOM-based", end =" ")
 rs.set_parameters({'rating_bias':False,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.0,'decayed':0.5,'ratings':0.5,'spendings':0.5})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 50, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+"""
+
+
+
+good_agent = {"buyers":[1,80], "products":[201,280], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
+bad_agent = {"buyers":[81,100], "products":[281,300], "qualities":[0.0,0.25], "transactions": bad_transactions}
+days = 20
+
+print("RS=Biased", end =" ")
+rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+
+good_agent = {"buyers":[1,80], "products":[201,280], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
+bad_agent = {"buyers":[81,120], "products":[281,320], "qualities":[0.0,0.25], "transactions": bad_transactions}
+days = 20
+
+print("RS=Biased", end =" ")
+rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+
+good_agent = {"buyers":[1,80], "products":[201,280], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
+bad_agent = {"buyers":[81,140], "products":[281,340], "qualities":[0.0,0.25], "transactions": bad_transactions}
+days = 20
+
+print("RS=Biased", end =" ")
+rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+
+good_agent = {"buyers":[1,80], "products":[201,280], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
+bad_agent = {"buyers":[81,160], "products":[281,360], "qualities":[0.0,0.25], "transactions": bad_transactions}
+days = 20
+
+print("RS=Biased", end =" ")
+rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+
 
 
 if rs is not None:


### PR DESCRIPTION
Confirming effect of "gaming competition cutting gaming profits":
RS=Biased PLRo=30 agents=80/20/80/20 days=20 Organic: 15960 Sponsored: 4000 Organic2Sponsored: 12880 Organic/Sponsored: 3.99 LTS: 0.81 PFS: 3.22
RS=Biased PLRo=30 agents=80/40/80/40 days=20 Organic: 16000 Sponsored: 8000 Organic2Sponsored: 13990 Organic/Sponsored: 2.0 LTS: 0.87 PFS: 1.75
RS=Biased PLRo=30 agents=80/60/80/60 days=20 Organic: 16000 Sponsored: 12000 Organic2Sponsored: 15000 Organic/Sponsored: 1.33 LTS: 0.94 PFS: 1.25
RS=Biased PLRo=30 agents=80/80/80/80 days=20 Organic: 16000 Sponsored: 16000 Organic2Sponsored: 15340 Organic/Sponsored: 1.0 LTS: 0.96 PFS: 0.96

agents=80/20/80/20 means agents=<honest_buyers>/<honest_buyers>/<honest_products>/<gaming_products>

<honest_products> quality is 0.5-1.0
<gaming_products> quality is 0.0-0.25
So I am using "old" LTS & PFS metrics for the time being with <gaming_products> considered as  <bad_sellers>.