### PR TITLE
reputation_buying true consistent reputations, selection of 4 or 5 stars

### DIFF
--- a/reputation/reputation_buying.py
+++ b/reputation/reputation_buying.py
@@ -146,6 +146,10 @@ def get_list_fraction(list,fraction,first):
 	return res_list
 
 
+def rand_list(list):
+	return list[random.randint(0,len(list)-1)]
+
+
 def get_prob_100(prob):
 	# 100 => True !
 	# 0 => False ! 
@@ -216,12 +220,11 @@ def reputation_simulate(good_agent,bad_agent,since,sim_days,ratings,threshold=40
 
 
 	costs = {}
+	qualities = {}
 	for product in all_products:
 		costs[product] = 10
-	
-	#TODO quality
-	#cost = random.randint(bad_agents_values[0],bad_agents_values[1])
-	
+		qualities[product] = rand_list(bad_agent['qualities']) if product in bad_agents else rand_list(good_agent['qualities'])
+
 	#if verbose:
 	#	print('Good:',len(good_agents),good_agents_values[0],good_agents_transactions,len(good_agents)*good_agents_values[0]*good_agents_transactions)
 	#	print('Bad:',len(bad_agents),bad_agents_values[0],bad_agents_transactions,len(bad_agents)*bad_agents_values[0]*bad_agents_transactions)
@@ -259,7 +262,8 @@ def reputation_simulate(good_agent,bad_agent,since,sim_days,ratings,threshold=40
 					buys += 1
 					actual_good_volume += cost
 					# while ratings range is [0.0, 0.25, 0.5, 0.75, 1.0], we rank good agents as [0.25, 0.5, 0.75, 1.0]
-					rating = 0.0 if other in bad_agents else float(random.randint(1,4))/4
+					#rating = 0.0 if other in bad_agents else float(random.randint(1,4))/4
+					rating = qualities[other]
 					daily_organic += cost
 					if other in bad_agents:
 						actual_good_to_bad_volume += cost

--- a/reputation/reputation_buying_test.py
+++ b/reputation/reputation_buying_test.py
@@ -47,6 +47,7 @@ verbose = False
 
 good_transactions = 1
 bad_transactions = 1
+threshold = 60
 
 good_agent = {"buyers":[1,800], "products":[1001,1800], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
 bad_agent = {"buyers":[801,1000], "products":[1801,2000], "qualities":[0.0,0.25], "transactions": bad_transactions}
@@ -64,37 +65,39 @@ days = 101
 #bad_agent = {"buyers":[4,5], "products":[9,10], "qualities":[0.0,0.25], "transactions": bad_transactions}
 #days = 5
 
-"""
+
 print("RS=None", end =" ")
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 0, None, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 0, None, verbose)
 
 print("RS=Regular", end =" ")
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 0, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 0, rs, verbose)
 
 print("RS=Regular", end =" ")
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 30, rs, verbose)
 
 print("RS=Regular", end =" ")
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 100, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 100, rs, verbose)
 
 print("RS=Weighted", end =" ")
 rs.set_parameters({'rating_bias':False,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 30, rs, verbose)
 
 print("RS=Biased", end =" ")
 rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 30, rs, verbose)
 
 print("RS=TOM-based", end =" ")
 rs.set_parameters({'rating_bias':False,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':True ,'default':0.0,'decayed':0.5,'ratings':1.0,'spendings':0.0})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 30, rs, verbose)
 	
 print("RS=SOM-based", end =" ")
 rs.set_parameters({'rating_bias':False,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.0,'decayed':0.5,'ratings':0.5,'spendings':0.5})
-reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
+reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, threshold, 30, rs, verbose)
+
+
+
 """
-
-
+# Confirming effect of "gaming competition cutting gaming profits"
 
 good_agent = {"buyers":[1,80], "products":[201,280], "qualities":[0.5,0.75,1.0], "transactions": good_transactions}
 bad_agent = {"buyers":[81,100], "products":[281,300], "qualities":[0.0,0.25], "transactions": bad_transactions}
@@ -127,7 +130,7 @@ days = 20
 print("RS=Biased", end =" ")
 rs.set_parameters({'rating_bias':True,'fullnorm':True,'weighting':True ,'logratings':False,'denomination':True ,'unrated':False,'default':0.5,'decayed':0.5,'ratings':1.0,'spendings':0.0})
 reputation_simulate(good_agent,bad_agent, datetime.date(2018, 1, 1), days, True, 80, 30, rs, verbose)
-
+"""
 
 
 if rs is not None:


### PR DESCRIPTION
$ python reputation_buying_test.py
RS=None PLRo=0 agents=80/20/80/20 days=101 Organic: 80000 Sponsored: 4000 Organic2Sponsored: 16000 Organic/Sponsored: 20.0 LTS: 0.2 PFS: 4.0
RS=Regular PLRo=0 agents=80/20/80/20 days=101 Organic: 16660 Sponsored: 4000 Organic2Sponsored: 16000 Organic/Sponsored: 4.17 LTS: 0.96 PFS: 4.0
RS=Regular PLRo=30 agents=80/20/80/20 days=101 Organic: 29210 Sponsored: 4000 Organic2Sponsored: 16000 Organic/Sponsored: 7.3 LTS: 0.55 PFS: 4.0
RS=Regular PLRo=100 agents=80/20/80/20 days=101 Organic: 49060 Sponsored: 4000 Organic2Sponsored: 9090 Organic/Sponsored: 12.27 LTS: 0.19 PFS: 2.27
RS=Weighted PLRo=30 agents=80/20/80/20 days=101 Organic: 26910 Sponsored: 4000 Organic2Sponsored: 14100 Organic/Sponsored: 6.73 LTS: 0.52 PFS: 3.52
RS=Biased PLRo=30 agents=80/20/80/20 days=101 Organic: 21090 Sponsored: 4000 Organic2Sponsored: 11540 Organic/Sponsored: 5.27 LTS: 0.55 PFS: 2.88
RS=TOM-based PLRo=30 agents=80/20/80/20 days=101 Organic: 29210 Sponsored: 4000 Organic2Sponsored: 16000 Organic/Sponsored: 7.3 LTS: 0.55 PFS: 4.0
RS=SOM-based PLRo=30 agents=80/20/80/20 days=101 Organic: 29210 Sponsored: 4000 Organic2Sponsored: 16000 Organic/Sponsored: 7.3 LTS: 0.55 PFS: 4.0
