### PR TITLE
Reputation tests  spendings progress

### DIFF
--- a/reputation/reputation_calculation.py
+++ b/reputation/reputation_calculation.py
@@ -148,7 +148,6 @@ def reputation_calc_p1(new_subset,conservatism,precision,temporal_aggregation=Fa
         new_subset = fix_rater_bias(new_subset,rater_bias,our_average)    
             
     i=0
-    
     new_array = []
     israting = True
     while i<len(new_subset):
@@ -283,7 +282,7 @@ def logratings_precision(rating,lograting,precision,weighting):
     new_weight = None # assume no weight computed by default
     ### if weighting = False, then we return values only.
     if not weighting:
-        return(rating[2],None)
+        return(rating[3],None)
     if lograting:
         ### We go through few posibilities about what can happen.
         ### If there are no weights then:
@@ -439,7 +438,6 @@ def calculate_new_reputation(logging,new_array,to_array,reputation,rating,precis
                 myd[unique_ids[i]] = sum(denominators)
 #
         i+=1
-    
     ### Let's update the records from previous reputations and how we update them (for raters)
     for k in prev_rep1a.keys():
         previous_rep[k] = prev_rep1a[k]

--- a/reputation/reputation_service_api.py
+++ b/reputation/reputation_service_api.py
@@ -306,7 +306,6 @@ class PythonReputationService(ReputationServiceBase):
                 self.downrating=False
         ### we set up arrays; this is the set of data where we have ratings, values, weights
         ### in predictable way, so we can iterate them later on.
-        
         if self.rating_bias:
             if 'average_ratings' in dir(self):
                 pass
@@ -321,8 +320,7 @@ class PythonReputationService(ReputationServiceBase):
         ### Now we update the reputation. Here, old ranings are inseter and then new ones are calculated as output.
 
         self.reputation = update_reputation(self.reputation,array1,self.default,self.spendings)
-
-        ### we take data from date-update_period.
+        
         
         ### If we have spendings-based reputation, we go in the loop below.
         if self.spendings>0:
@@ -340,6 +338,20 @@ class PythonReputationService(ReputationServiceBase):
         text = "Normalized differential: " + str(new_reputation)
         logging.debug(text)  
         ### Again only starting this loop if we have spendings.
+        ### we take data from date-update_period.
+        ### For spendings-based system. We store all agents' reputations and then we only show reputations of
+        ### sellers when get_ranks() is called. This is not in line with Java implementation, which only returns
+        ### sellers. To circumvent that, we make an object in which we store only sellers and we then return only sellers.
+        ### We still need all ranks, so they are still stored in self.all_reputations
+        
+        if "sellers" in dir(self):
+            pass
+        else:
+            self.sellers = []
+        
+        for k in new_reputation.keys():
+            if k not in self.sellers:
+                self.sellers.append(k)
         if (self.spendings>0 and self.predictiveness==0):
             updated_differential = dict()
             unique_keys = list(new_reputation.keys())
@@ -427,6 +439,13 @@ class PythonReputationService(ReputationServiceBase):
             all_results.append({'id':k,'rank':my_round(result[k]*100,0)})  
         #logging.debug("network get ranks: ",str(all_results))
         logging.info("network get ranks: {0}".format(all_results))
+        ### Now, if we have spending, we only return those that are sellers;
+        #if self.spendings>0:
+        #    my_results = dict()
+        #    for k in all_results.keys():
+        #        if k in self.sellers:
+        #            my_results[k] = all_results[k]       
+        #    all_results=my_results                    
         return(0,all_results)
     ### get_ranks_dict is similar as get_ranks
     def get_ranks_dict(self,times):
@@ -442,6 +461,12 @@ class PythonReputationService(ReputationServiceBase):
             ### Everything is similar to get_ranks, but we only return result, not really 0 beside result.
         #logging.debug("network get ranks: " , str(result))
         logging.info("network get ranks: {0}".format(result))
+        #if self.spendings>0:
+        #    my_results = dict()
+        #    for k in result.keys():
+        #        if k in self.sellers:
+        #            my_results[k] = result[k]
+        #    result=my_results
         return(result)    
 
     ### Getting ratings from Python rs.

--- a/reputation/test_reputation.py
+++ b/reputation/test_reputation.py
@@ -384,7 +384,6 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		"""
 		self.assertEqual(rs.update_ranks(dt2), 0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		#print(ranks)
 		#input("      - Press Enter -")
 		self.assertEqual(len(ranks), 4)
 		self.assertEqual(ranks['1'], 74)
@@ -400,7 +399,6 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		self.assertEqual( rs.put_ratings([{'from':'3','type':'rating','to':'4','value': 1.0,'weight':10,'time':dt2}]), 0 )
 		self.assertEqual(rs.update_ranks(dt2), 0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		#print(ranks)
 		self.assertEqual(len(ranks), 4)
 		self.assertEqual(ranks['4'], 0)
 
@@ -461,7 +459,6 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':3,'value':50,'weight':1,'time':dt2}]), 0 )
 		self.assertEqual(rs.update_ranks(dt2), 0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		#print(ranks)
 		self.assertEqual(len(ranks), 2)
 		# with financial denomination
 		self.assertEqual(ranks['3'], 96) # because its logarithmic differential is not normalized down to 0
@@ -480,7 +477,6 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':4,'value':1000,'weight':None,'time':dt2}]), 0 )
 		self.assertEqual(rs.update_ranks(dt2), 0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		#print(ranks)
 		self.assertEqual(len(ranks), 3)
 		self.assertEqual(ranks['3'], 56)
 		self.clear()
@@ -490,7 +486,6 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':4,'value':1000,'weight':None,'time':dt2}]), 0 )
 		self.assertEqual(rs.update_ranks(dt2), 0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		#print(ranks)
 		self.assertEqual(len(ranks), 3)
 		self.assertEqual(ranks['3'], 50)
 
@@ -615,20 +610,16 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		dt3 = date(2018, 1, 3)
 		dt4 = date(2018, 1, 4)
 		for unrated in [False]:
-			#print('Unrated:',unrated)
 			rs.set_parameters({'unrated':unrated})
-			#print(rs.get_parameters())
 			self.assertEqual( self.rs.clear_ratings(), 0 )
 			self.assertEqual( self.rs.clear_ranks(), 0 )
 			self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':2,'value':1,'weight':1,'time':dt2}]), 0 )
 			self.assertEqual(rs.update_ranks(dt2),0)
 			ranks = rs.get_ranks_dict({'date':dt2})
-			#print(ranks)
 			self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':2,'value':1,'weight':1,'time':dt3}]), 0 )
 			self.assertEqual( rs.put_ratings([{'from':3,'type':'rating','to':4,'value':1,'weight':1,'time':dt3}]), 0 )
 			self.assertEqual(rs.update_ranks(dt3),0)
 			ranks = rs.get_ranks_dict({'date':dt3})
-			#print(ranks)
 			self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':6,'value':1,'weight':1,'time':dt4}]), 0 )
 			self.assertEqual( rs.put_ratings([{'from':3,'type':'rating','to':8,'value':1,'weight':1,'time':dt4}]), 0 )
 			self.assertEqual( rs.put_ratings([{'from':5,'type':'rating','to':10,'value':1,'weight':1,'time':dt4}]), 0 )
@@ -644,21 +635,18 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		dt2 = date(2018, 1, 2)
 		dt3 = date(2018, 1, 3)
 		dt4 = date(2018, 1, 4)
-		#print(rs.get_parameters())
 		self.assertEqual( self.rs.clear_ratings(), 0 )
 		self.assertEqual( self.rs.clear_ranks(), 0 )
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':10,'value':1,'weight':1,'time':dt2}]), 0 )
 		self.assertEqual(rs.update_ranks(dt2),0)
 		ranks = rs.get_ranks_dict({'date':dt2})
 		self.assertDictEqual(ranks,{'1': 25.0, '10': 0.0})
-		#print(ranks)
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':10,'value':1,'weight':1,'time':dt3}]), 0 )
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':11,'value':1,'weight':1,'time':dt3}]), 0 )
 		self.assertEqual( rs.put_ratings([{'from':2,'type':'rating','to':20,'value':1,'weight':1,'time':dt3}]), 0 )
 		self.assertEqual(rs.update_ranks(dt3),0)
 		ranks = rs.get_ranks_dict({'date':dt3})
 		self.assertDictEqual(ranks,{'10': 100.0, '11': 100.0, '1': 75.0, '2': 25.0, '20': 0.0})
-		#print(ranks)
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':10,'value':1,'weight':1,'time':dt4}]), 0 )
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':11,'value':1,'weight':1,'time':dt4}]), 0 )
 		self.assertEqual( rs.put_ratings([{'from':1,'type':'rating','to':12,'value':1,'weight':1,'time':dt4}]), 0 )
@@ -885,7 +873,6 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		ranks2 = rs.get_ranks_dict({'date':dt2})
 		#print(,ranks2)
 		ranks3 = rs.get_ranks_dict({'date':dt3})
-		#print("ranks3",ranks3)
 		self.assertDictEqual(ranks3,{'2': 100.0, '1': 67.0, '4': 67.0, '6': 67.0, '3': 33.0, '5': 33.0})
         
 	def test_rater_bias(self):
@@ -915,7 +902,7 @@ class TestReputationServiceParametersBase(TestReputationServiceBase):
 		rs.clear_ratings()
 		rs = self.rs
         ####And now rating_bias=True
-        
+       
 
         
         
@@ -946,8 +933,6 @@ class TestReputationServiceAdvanced(TestReputationServiceParametersBase):
 
 		ranks = rs.get_ranks_dict({'date':dt2})
 		self.assertEqual(ranks['1'],68)
-        
-
 		rs.set_parameters({'default':0.5,'decayed':0.5,'conservatism':0.25,'fullnorm':False,'logratings':False,'liquid':True,'rating_bias':True})
 		self.assertEqual(rs.put_ratings([{'from':'1','type':'rating','to':'4','value':0.5,'weight':10,'time':dt1}]),0)
 		self.assertEqual(rs.put_ratings([{'from':'2','type':'rating','to':'5','value':1.0,'weight':10,'time':dt1}]),0)
@@ -960,29 +945,11 @@ class TestReputationServiceAdvanced(TestReputationServiceParametersBase):
 		self.assertEqual(rs.put_ratings([{'from':3,'type':'rating','to':'4','value':0.75,'weight':10,'time':dt2}]),0)
 		self.assertEqual(rs.update_ranks(dt2),0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		print("ranks:",ranks)
 		self.assertDictEqual(ranks, {'1': 72.0, '2': 100.0, '4': 69.0, '5': 27.0, '6': 4.0})        
         
-        
-	def test_weighting_false_spending(self):
-		print('Testing '+type(self).__name__+' spendings_normalization')
-		rs = self.rs
-		rs.clear_ratings()
-		rs.clear_ranks()
-		dt2 = date(2018, 1, 2)
-		rs.set_parameters({'fullnorm':True,'weighting':False,'logratings':False,'denomination':False,'unrated':False,'default':0.5,'decayed':0.5,'conservatism':0.5,'ratings':0.5,'spendings':0.5})
-		rs.put_ratings([{'from':5,'type':'rating','to':2,'value':0.25,'weight':682,'time':dt2}])
-		self.assertEqual(rs.put_ratings([{'from':5,'type':'rating','to':2,'value':0.25,'weight':682,'time':dt2}]),0)
-		self.assertEqual(rs.put_ratings([{'from':6,'type':'rating','to':3,'value':1,'weight':220,'time':dt2}]),0)
-		self.assertEqual(rs.put_ratings([{'from':7,'type':'rating','to':4,'value':1,'weight':583,'time':dt2}]),0)
-		self.assertEqual(rs.put_ratings([{'from':8,'type':'rating','to':2,'value':1,'weight':196,'time':dt2}]),0)
-		self.assertEqual(rs.put_ratings([{'from':10,'type':'rating','to':9,'value':1,'weight':129,'time':dt2}]),0)
-		rs.update_ranks(dt2)
-		#self.assertEqual(rs.update_ranks(dt2),0)
-		ranks = rs.get_ranks_dict({'date':dt2})
-		self.assertDictEqual(ranks,{'2': 100.0, '5': 100.0, '3': 61.0, '6': 61.0, '4': 80.0, '7': 82.0, '8': 59.0, '9': 50.0, '10': 50.0})        
+ 
 	def test_predictiveness(self):
-		print('Testing '+type(self).__name__+' spendings_normalization')
+		print('Testing '+type(self).__name__+' predictiveness')
 		rs = self.rs
 		rs.clear_ratings()
 		rs.clear_ranks()
@@ -1022,7 +989,7 @@ class TestReputationServiceAdvanced(TestReputationServiceParametersBase):
         
         
 	def test_predictiveness_v2(self):
-		print('Testing '+type(self).__name__+' spendings_normalization')
+		print('Testing '+type(self).__name__+' predictiveness_v2')
 		rs = self.rs
 		rs.clear_ratings()
 		rs.clear_ranks()
@@ -1070,11 +1037,11 @@ class TestReputationServiceAdvanced(TestReputationServiceParametersBase):
 			self.assertEqual(rs.put_ratings([{'from':3,'type':'rating','to':'4','value':0.75,'weight':10,'time':dt2}]),0)
 			self.assertEqual(rs.update_ranks(dt2),0)
 			ranks = rs.get_ranks_dict({'date':dt2})
-			#print(ranks)
 			if rating_bias == False:
 				self.assertDictEqual(ranks,{'4': 99.0, '5': 100.0, '6': 89.0})
 			else:
 				self.assertDictEqual(ranks,{'5': 100.0, '4': 99.0, '6': 22.0})               
+ 
 	def test_weighting_false_spending(self):
 		print('Testing '+type(self).__name__+' spendings_normalization')
 		rs = self.rs
@@ -1091,7 +1058,7 @@ class TestReputationServiceAdvanced(TestReputationServiceParametersBase):
 		rs.update_ranks(dt2)
 		#self.assertEqual(rs.update_ranks(dt2),0)
 		ranks = rs.get_ranks_dict({'date':dt2})
-		self.assertDictEqual(ranks,{'2': 100.0, '5': 100.0, '3': 61.0, '6': 61.0, '4': 80.0, '7': 82.0, '8': 59.0, '9': 50.0, '10': 50.0})  
+		self.assertDictEqual(ranks, {'2': 100.0, '5': 50.0, '3': 100.0, '6': 100.0, '4': 100.0, '7': 100.0, '8': 100.0, '9': 100.0, '10': 100.0})                
                 
         
 class TestReputationServiceAigents(TestReputationServiceParametersBase):
@@ -1123,7 +1090,6 @@ class TestReputationServiceAigents(TestReputationServiceParametersBase):
 			self.assertEqual(rs.put_ratings([{'from':3,'type':'rating','to':'4','value':0.75,'weight':10,'time':dt2}]),0)
 			self.assertEqual(rs.update_ranks(dt2),0)
 			ranks = rs.get_ranks_dict({'date':dt2})
-			#print(ranks)
 			if rating_bias == False:
 				self.assertDictEqual(ranks,{'4': 99.0, '5': 100.0, '6': 89.0})
 			else:
@@ -1154,7 +1120,6 @@ class TestReputationServiceAigents(TestReputationServiceParametersBase):
 			self.assertEqual( rs.put_ratings([{'from':3,'type':'rating','to':14,'value':1,'weight':10,'time':dt2}]), 0 )
 			self.assertEqual(rs.update_ranks(dt2), 0)
 			ranks = rs.get_ranks_dict({'date':dt2})
-			#print(ranks)
 			#self.assertDictEqual(ranks,{'11': 100.0, '12': 33.0})
 			#day 2
 			#self.assertEqual( rs.put_ratings([{'from':2,'type':'rating','to':13,'value':1,'weight':10,'time':dt3}]), 0 )
@@ -1163,7 +1128,6 @@ class TestReputationServiceAigents(TestReputationServiceParametersBase):
 			#self.assertEqual( rs.put_ratings([{'from':3,'type':'rating','to':14,'value':1,'weight':10,'time':dt3}]), 0 )
 			self.assertEqual(rs.update_ranks(dt3), 0)
 			ranks = rs.get_ranks_dict({'date':dt3})
-			#print(ranks)
 			if parents == 0.0:
 				self.assertDictEqual(ranks,{'11': 100.0, '14': 100.0, '12': 55.0})
 			else:
@@ -1200,7 +1164,6 @@ class TestReputationServiceAigents(TestReputationServiceParametersBase):
 			self.assertEqual( rs.put_ratings([{'from':3,'type':'rating','to':14,'value':1,'weight':10,'time':dt3}]), 0 )
 			self.assertEqual(rs.update_ranks(dt3), 0)
 			ranks = rs.get_ranks_dict({'date':dt3})
-			#print(ranks)
 			if predictiveness == 0.0:
 				self.assertDictEqual(ranks,{'11': 100.0, '13': 100.0, '14': 100.0, '12': 55.0})
 			else:


### PR DESCRIPTION
Spendings are  still not working exactly the same as in Java, but now the differences are not that big. The most major difference is that sometimes Java returns the ranks of both sellers and buyers and sometimes of just sellers. Python always returns only ranks of both. This is when spendigs>0. The ranks are the same in both implementations though. Given that calculations are the same, it does not seem to be a critical issue to me.